### PR TITLE
Fixing finite part of triangle configuration with real masses and m1=p1, m2=m3=p2=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,11 @@ configure_file(
 set(QUADMATH_NAMES ${QUADMATH_NAMES} libquadmath.so quadmath)
 find_library(QUADMATH_LIBRARY
   NAMES ${QUADMATH_NAMES}
-  PATHS /usr/lib64/atlas /usr/lib/atlas 
-        /usr/lib64 /usr/lib /usr/local/lib64 
+  PATHS /usr/lib64/atlas /usr/lib/atlas
+        /usr/lib64 /usr/lib /usr/local/lib64
         /usr/local/lib /usr/x86_64-linux-gnu/*
         /usr/lib/gcc/x86_64-linux-gnu/*
+        /usr/lib/gcc/x86_64-redhat-linux/*
 )
 
 if(QUADMATH_LIBRARY)
@@ -105,7 +106,7 @@ if(ENABLE_EXAMPLES)
   add_executable(cache_test examples/cache_test.cc)
   target_link_libraries(cache_test qcdloop ${QUADMATH_LIBRARIES})
   set_target_properties(cache_test PROPERTIES LINK_FLAGS "-Wl,-rpath,./")
-  
+
   add_executable(cmass_test examples/cmass_test.cc)
   target_link_libraries(cmass_test qcdloop ${QUADMATH_LIBRARIES})
   set_target_properties(cmass_test PROPERTIES LINK_FLAGS "-Wl,-rpath,./")

--- a/src/qcdloop-config.in
+++ b/src/qcdloop-config.in
@@ -28,7 +28,7 @@ tmp=$( echo "$*" | egrep -- '--\<incdir\>')
 test -n "$tmp" && OUT="$OUT @includedir@"
 
 tmp=$( echo "$*" | egrep -- '--\<cppflags\>')
-test -n "$tmp" && OUT="$OUT -I@includedir@"
+test -n "$tmp" && OUT="$OUT -I@includedir@ -std=c++11"
 
 tmp=$( echo "$*" | egrep -- '--\<libdir\>')
 test -n "$tmp" && OUT="$OUT @libdir@"

--- a/src/qcdloop/maths.h
+++ b/src/qcdloop/maths.h
@@ -34,7 +34,7 @@ namespace ql
   inline qcomplex Sqrt(qcomplex const& x){ return csqrtq(x); }
 
   // Absolute value
-  inline double  Abs(double const& x)   { return std::fabs(x); }
+  inline double  Abs(double const& x)   { return std::abs(x); }
   inline qdouble Abs(qdouble const& x)  { return fabsq(x);}
   inline double  Abs(complex const& x)  { return std::abs(x);}
   inline qdouble Abs(qcomplex const& x) { return cabsq(x); }

--- a/src/qcdloop/maths.h
+++ b/src/qcdloop/maths.h
@@ -36,7 +36,7 @@ namespace ql
   // Absolute value
   inline double  Abs(double const& x)   { return std::fabs(x); }
   inline qdouble Abs(qdouble const& x)  { return fabsq(x);}
-  inline double  Abs(complex const& x)  { return std::fabs(x);}
+  inline double  Abs(complex const& x)  { return std::abs(x);}
   inline qdouble Abs(qcomplex const& x) { return cabsq(x); }
 
   // Complex tools, imag, real and conj.

--- a/src/triangle.cc
+++ b/src/triangle.cc
@@ -888,7 +888,7 @@ namespace ql
     const TOutput ct = TOutput(this->_pi2o6);
 
     TOutput dilog2;
-    if (Abs(omarg2) < this->_zero)
+    if (Real(omarg2) < this->_zero)
       dilog2 = ct-TOutput(this->ddilog(omarg2))-Log(arg2)*wlog;
     else
       dilog2 = TOutput(this->ddilog(arg2));


### PR DESCRIPTION
This PR fixes a bug in the triangle computation when `m1=p1` and `m2=m3=p2=0` in real mass regime.
We thank @JacekHoleczek for pointing out this issue.

### Bug description

The following configuration:
```c++
  double mu2 = 1;
  vector<double> p = { 3.0380490000000004e+00 , 0.0000000000000000e+00 , 3.2368307443778059e+00 };
  vector<double> m = { 3.0380490000000004e+00 , 0.0000000000000000e+00 , 0.0000000000000000e+00 };
  vector<complex> res(3);
  ql::Triangle<complex,double> tr;
  tr.integral(res, mu2, m, p);
```
generates the wrong output for the finite part:
```
eps0 = ( -1.2330490063749579e+01 , 2.5532491289035740e+01 )
eps1 = (  1.0922308743166440e+01 , 1.5804231235735950e+01 )
eps2 = (  2.5153215229347099e+00 , 0.0000000000000000e+00 )
```

### Expected behaviour

This PR fixes the issue. The final output is:
```
eps0 = ( -1.2330490063749521e+01 , 6.9628548600292163e+01 )
eps1 = (  1.0922308743166440e+01 , 1.5804231235735934e+01 )
eps2 = (  2.5153215229347099e+00 , 0.0000000000000000e+00 )
```


@JacekHoleczek could you please test this branch and let me know if this fixes the issue you have reported?