### PR TITLE
Fix an off-by-one error in Tools::ddilog

### DIFF
--- a/src/tools.cc
+++ b/src/tools.cc
@@ -368,7 +368,7 @@ namespace ql {
     const TMass H = Y+Y-_one;
     const TMass ALFA = H+H;
     TMass B1 = _zero, B2 = _zero, B0 = _zero;
-    for (int i = _C.size(); i >= 0; i--)
+    for (int i = _C.size() - 1; i >= 0; i--)
       {
         B0 = _C[i]+ALFA*B1-B2;
         B2 = B1;


### PR DESCRIPTION
The loop over coefficients `_C` starts with index `i=_C.size()`, which is out of bounds because the last element has index `i=_C.size()-1`.

This does not matter if the uninitialized `_C[_C.size()]` happens to be zero, but I believe this is not guaranteed.