### PR TITLE
Add one more QUADMATH lookup path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ find_library(QUADMATH_LIBRARY
         /usr/local/lib /usr/x86_64-linux-gnu/*
         /usr/lib/gcc/x86_64-linux-gnu/*
         /usr/lib/gcc/x86_64-redhat-linux/*
+        /usr/lib/gcc/x86_64-pc-linux-gnu/*
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
 )
 


### PR DESCRIPTION
This path is where gentoo's gcc toolchain resides.