### PR TITLE
docs: Add conda-forge install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Homepage with library description: https://qcdloop.web.cern.ch
 If you use this code in your publication, please cite
 [arXiv:0712.1851](http://arxiv.org/abs/0712.1851) and
 [arXiv:1605.03181](http://arxiv.org/abs/1605.03181).
- 
+
 ## Download
 
 You can obtain QCDLoop releases directly from the github repository:
@@ -31,7 +31,9 @@ git tag -l
 git checkout tags/tag_name
 ```
 
-## Installation 
+## Installation
+
+### From source
 
 Checkout the code and compile the code using the
 following procedure:
@@ -44,15 +46,34 @@ make && make install
 ```
 
 By the default, if prefix is not set the program is installed in
-/usr/local. If you define a custom prefix, use the `-DCMAKE_INSTALL_PREFIX` option and 
-remember to export qcdloop/lib to the LD_LIBRARY_PATH. QCDLoop requires a compiler with
-C++11 and quadmath features (e.g. gcc >= 5).
+`/usr/local`. If you define a custom prefix, use the `-DCMAKE_INSTALL_PREFIX` option and
+remember to export `qcdloop/lib` to the `LD_LIBRARY_PATH`. QCDLoop requires a compiler with
+C++11 and `quadmath` features (e.g. `gcc >= 5`).
 
 Other qcdloop cmake options are:
-- `ENABLE_EXAMPLES`, build examples in C++, default OFF.
-- `ENABLE_FORTRAN_WRAPPER`, include fortran wrapper in the library, default ON.
+- `ENABLE_EXAMPLES`, build examples in C++, default `OFF`.
+- `ENABLE_FORTRAN_WRAPPER`, include fortran wrapper in the library, default `ON`.
 
-The fortran wrapper follows the previous syntax in qcdloop, see details in table 2 of https://arxiv.org/pdf/1605.03181.pdf.
+The fortran wrapper follows the previous syntax in `qcdloop`, see details in table 2 of https://arxiv.org/pdf/1605.03181.pdf.
+
+### From conda-forge
+
+QCDLoop is packaged and distributed on [conda-forge](https://github.com/conda-forge/qcdloop-feedstock/) for the following platforms:
+
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/qcdloop.svg)](https://anaconda.org/conda-forge/qcdloop)
+[![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qcdloop.svg)](https://anaconda.org/conda-forge/qcdloop)
+
+To install and add QCDLoop to a project with [`pixi`](https://pixi.sh/), from the project directory run
+
+```
+pixi add qcdloop
+```
+
+and to install into a particular conda environment with [`conda`](https://docs.conda.io/projects/conda/), in the activated environment run
+
+```
+conda install --channel conda-forge qcdloop
+```
 
 ## Contact Information
 


### PR DESCRIPTION
Resolves #30 

* Add instructions for `pixi` and `conda` for installing `qcdloop` from conda-forge.
   - c.f. https://github.com/conda-forge/qcdloop-feedstock/