### PR TITLE
fix: Add back support for ppc64le

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ configure_file(
   )
 # Only enable quadmath for non-aarch64 as aarch64 supports float128 and so
 # doesn't have libquadmath
-IF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+IF(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|arm")
 set(QUADMATH_NAMES ${QUADMATH_NAMES} libquadmath.so quadmath)
 find_library(QUADMATH_LIBRARY
   NAMES ${QUADMATH_NAMES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/src/qcdloop.pc.in"
   "${PROJECT_SOURCE_DIR}/src/qcdloop.pc"
   )
-IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+# Only enable quadmath for non-aarch64 as aarch64 supports float128 and so
+# doesn't have libquadmath
+IF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
 set(QUADMATH_NAMES ${QUADMATH_NAMES} libquadmath.so quadmath)
 find_library(QUADMATH_LIBRARY
   NAMES ${QUADMATH_NAMES}

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -17,7 +17,7 @@ namespace std {
     seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   template <>
   struct hash<ql::qdouble> : public __hash_base<size_t, ql::qdouble>
   {

--- a/src/qcdloop/maths.h
+++ b/src/qcdloop/maths.h
@@ -21,7 +21,7 @@ namespace ql
 {
   // Logarithms
   inline double   Log(double const& x)   { return std::log(x); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble  Log(qdouble const& x)  { return logq(x); }
   inline qcomplex Log(qcomplex const& x) { return clogq(x); }
 #endif
@@ -33,7 +33,7 @@ namespace ql
 
   // Power
   inline double   Pow(double const& x, int const& a)   { return std::pow(x, a); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble  Pow(qdouble const& x, int const& a)  { return powq(x,a); }
   inline qcomplex Pow(qcomplex const& x, int const& a){ return cpowq(x,a); }
 #endif
@@ -45,7 +45,7 @@ namespace ql
 
   // Root
   inline double   Sqrt(double const& x)  { return std::sqrt(x); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble  Sqrt(qdouble const& x) { return sqrtq(x); }
   inline qcomplex Sqrt(qcomplex const& x){ return csqrtq(x); }
 #endif
@@ -57,7 +57,7 @@ namespace ql
 
   // Absolute value
   inline double  Abs(double const& x)   { return std::abs(x); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble Abs(qdouble const& x)  { return fabsq(x);}
   inline qdouble Abs(qcomplex const& x) { return cabsq(x); }
 #endif
@@ -71,7 +71,7 @@ namespace ql
   inline double  Imag(double const& x)  { UNUSED(x); return 0; }
   inline qdouble Imag(qdouble const& x) { UNUSED(x); return qdouble(0); }
   inline double  Imag(complex const& x) { return x.imag(); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble Imag(qcomplex const& x){ return cimagq(x);}
 #endif
 #if defined(__aarch64__)
@@ -81,7 +81,7 @@ namespace ql
   inline double  Real(double const& x) { return x; }
   inline qdouble Real(qdouble const& x) { return x; }
   inline double  Real(complex const& x) { return x.real(); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qdouble Real(qcomplex const& x) { return crealq(x); }
 #endif
 #if defined(__aarch64__)
@@ -89,7 +89,7 @@ namespace ql
 #endif
 
   inline complex  Conjg(complex const& x) { return std::conj(x); }
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   inline qcomplex Conjg(qcomplex const& x){ return conjq(x); }
 #endif
 #if defined(__aarch64__)

--- a/src/qcdloop/types.h
+++ b/src/qcdloop/types.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
 extern "C" { // for gcc4.7 compatibility
 #include <quadmath.h>
 }
@@ -49,7 +49,7 @@ namespace ql
 namespace std
 {
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   //! implementation of operator<< for qdouble
   ostream& operator<<(std::ostream& out, ql::qdouble f);
 #endif

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -20,7 +20,7 @@ namespace ql {
   template<typename TOutput, typename TMass, typename TScale>
   Tools<TOutput,TMass,TScale>::Tools():
     _qlonshellcutoff(is_same<TScale,double>::value ? 1e-10 : 1e-20q),
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
     _pi(is_same<TScale,double>::value ? M_PI : M_PIq),
 #endif
 #if defined(__aarch64__)

--- a/src/types.cc
+++ b/src/types.cc
@@ -9,7 +9,7 @@
 
 namespace std
 {
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
   ostream& operator<<(std::ostream& out, ql::qdouble f)
   {
      char buf[200];


### PR DESCRIPTION
* ppc64 little-endian is a supported architecture both on conda-forge and used in HPC systems. Add back support for it by only disabling libquadmath on aarch64 builds and by checking for the ppc64 in header files.
* Amends parts of PR #34.
* c.f. https://github.com/conda-forge/qcdloop-feedstock/pull/8